### PR TITLE
Python retrieve matrices and vectors K, k, P, p

### DIFF
--- a/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_ocp_qp_sol.py
+++ b/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_ocp_qp_sol.py
@@ -86,14 +86,6 @@ class hpipm_ocp_qp_sol:
 				'n_var': __hpipm.d_ocp_qp_dim_get_nx,
 				'var': __hpipm.d_ocp_qp_sol_get_pi
 			},
-			'lam_lb': {
-				'n_var': __hpipm.d_ocp_qp_dim_get_nbx,
-				'var': __hpipm.d_ocp_qp_sol_get_lam_lb
-			},
-			'lam_ub': {
-				'n_var': __hpipm.d_ocp_qp_dim_get_nbx,
-				'var': __hpipm.d_ocp_qp_sol_get_lam_ub
-			},
 			'lam_lbx': {
 				'n_var': __hpipm.d_ocp_qp_dim_get_nbx,
 				'var': __hpipm.d_ocp_qp_sol_get_lam_lbx
@@ -101,6 +93,14 @@ class hpipm_ocp_qp_sol:
 			'lam_ubx': {
 				'n_var': __hpipm.d_ocp_qp_dim_get_nbx,
 				'var': __hpipm.d_ocp_qp_sol_get_lam_ubx
+			},
+			'lam_lbu': {
+				'n_var': __hpipm.d_ocp_qp_dim_get_nbu,
+				'var': __hpipm.d_ocp_qp_sol_get_lam_lbu
+			},
+			'lam_ubu': {
+				'n_var': __hpipm.d_ocp_qp_dim_get_nbu,
+				'var': __hpipm.d_ocp_qp_sol_get_lam_ubu
 			}
 		}
 

--- a/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_ocp_qp_sol.py
+++ b/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_ocp_qp_sol.py
@@ -81,6 +81,26 @@ class hpipm_ocp_qp_sol:
 			'su': {
 				'n_var': __hpipm.d_ocp_qp_dim_get_ns,
 				'var': __hpipm.d_ocp_qp_sol_get_su
+			},
+			'pi': {
+				'n_var': __hpipm.d_ocp_qp_dim_get_nx,
+				'var': __hpipm.d_ocp_qp_sol_get_pi
+			},
+			'lam_lb': {
+				'n_var': __hpipm.d_ocp_qp_dim_get_nbx,
+				'var': __hpipm.d_ocp_qp_sol_get_lam_lb
+			},
+			'lam_ub': {
+				'n_var': __hpipm.d_ocp_qp_dim_get_nbx,
+				'var': __hpipm.d_ocp_qp_sol_get_lam_ub
+			},
+			'lam_lbx': {
+				'n_var': __hpipm.d_ocp_qp_dim_get_nbx,
+				'var': __hpipm.d_ocp_qp_sol_get_lam_lbx
+			},
+			'lam_ubx': {
+				'n_var': __hpipm.d_ocp_qp_dim_get_nbx,
+				'var': __hpipm.d_ocp_qp_sol_get_lam_ubx
 			}
 		}
 

--- a/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_ocp_qp_solver.py
+++ b/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_ocp_qp_solver.py
@@ -90,8 +90,8 @@ class hpipm_ocp_qp_solver(hpipm_solver):
 				'var': __hpipm.d_ocp_qp_ipm_get_ric_p
 			},
 			'ric_K': {
-				'n_row': __hpipm.d_ocp_qp_dim_get_nu,
-				'n_col': __hpipm.d_ocp_qp_dim_get_nx,
+				'n_row': __hpipm.d_ocp_qp_dim_get_nx,
+				'n_col': __hpipm.d_ocp_qp_dim_get_nu,
 				'var': __hpipm.d_ocp_qp_ipm_get_ric_K
 			},
 			'ric_k': {
@@ -133,9 +133,15 @@ class hpipm_ocp_qp_solver(hpipm_solver):
 			else:
 				n_col[0] = 1
 
-			var.append(np.zeros((n_row[0], n_col[0])))
-			tmp_ptr = cast(var[-1].ctypes.data, POINTER(c_double))
+			var_tmp = np.zeros((n_row[0], n_col[0]))
+			# tmp_ptr = cast(var[-1].ctypes.data, POINTER(c_double))
+			tmp_ptr = cast(var_tmp.ctypes.data, POINTER(c_double))
 			getter['var'](qp.qp_struct, self.arg.arg_struct, self.ipm_ws_struct, i, tmp_ptr)
+
+			if not 'n_col' in getter:
+				var.append(var_tmp)
+			else: 
+				var.append(var_tmp.T) # Needs to be transposed such that the correct gain K is returned
 
 		return var if idx_end is not None else var[0]
 

--- a/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_ocp_qp_solver.py
+++ b/interfaces/python/hpipm_python/hpipm_python/wrapper/hpipm_ocp_qp_solver.py
@@ -127,7 +127,7 @@ class hpipm_ocp_qp_solver(hpipm_solver):
 			else:
 				n_col[0] = 1
 
-			var.append(np.zeros((n_row[0], n_col[0]), dtype=np.float))
+			var.append(np.zeros((n_row[0], n_col[0])))
 			tmp_ptr = cast(var[-1].ctypes.data, POINTER(c_double))
 			getter['var'](qp.qp_struct, self.arg.arg_struct, self.ipm_ws_struct, i, tmp_ptr)
 


### PR DESCRIPTION
Changed the format how the gain matrices K, feedforward vector k, and the matrices P, and vectors p are retrieved from HPIPM. The matrices were tested on a manual DMS forward sweep and compared with HPIPM yielding the same solution.